### PR TITLE
Show members reactively

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,32 +4,15 @@ import { createEffect } from 'solid-js'
 import './styles.css'
 import Control from './components/Control'
 import User from './components/user/User'
-import { users, addNewUser, addStatus } from './store/users'
+import { addNewUser, addStatus } from './store/users'
 import { publishedMsgProofs, publishQueue, setPublishedMsgProofs } from './store/store'
 import PublishedMessages from './components/PublishedMessages'
 
 addNewUser();
 addNewUser();
-const user1 = users[0];
-const user2 = users[1];
-
-
 
 
 const App: Component = () => {
-  createEffect(() => {
-    // Add User1 to both registries
-    user1.registry.get().addMember(user1.rln.get().commitment)
-    user2.registry.get().addMember(user1.rln.get().commitment)
-    console.log("User1 Registered")
-  })
-
-  createEffect(() => {
-    // Add User2 to both registries
-    user2.registry.get().addMember(user2.rln.get().commitment)
-    user1.registry.get().addMember(user2.rln.get().commitment)
-    console.log("User2 Registered")
-  })
 
   createEffect(() => {
     // Add proofs to the cache from the publish queue (starting from the end)

--- a/src/components/user/Cache.tsx
+++ b/src/components/user/Cache.tsx
@@ -1,7 +1,6 @@
 import { poseidon1 } from "poseidon-lite"
 import { EvaluatedProof } from "rlnjs/dist/types/cache"
 import { Accessor } from "solid-js"
-import { toString } from '../../../src_react/utils'
 
 
 export type Props = {
@@ -9,7 +8,6 @@ export type Props = {
 }
 
 const CacheComponent = ({ status }: Props) => {
-  console.log(status())
   return (
     <div class="container box">
       <h3>Cache Status</h3>

--- a/src/store/users.ts
+++ b/src/store/users.ts
@@ -53,6 +53,16 @@ export const addNewUser = () => {
     const _registry = new Registry()
     const _cache = new Cache(appID() as StrBigInt)
 
+    // register user itself
+    _registry.addMember(_rln.commitment)
+    users.forEach((existingUser) => {
+        // new user
+        _registry.addMember(existingUser.rln.get().commitment)
+        // existing user
+        existingUser.registry.get().addMember(_rln.commitment)
+        existingUser.registry.set( existingUser.registry.get() )
+    })
+
     // use reactive states
     const [rln, setRln] = createSignal(_rln)
     const [registry, setRegistry] = createSignal(_registry)


### PR DESCRIPTION
I just fixed issue #3 (close #3) by moving the `createEffect` logic to the `addNewUser` function. The problem was that in App.tsx the steps executed were:

1. Build the components (`Registry.tsx` included)
2. Execute the `createEffect` logic

This order messed up with the `registry.get().members` attribute in the first load. That was why in a subsequent change (not page refreshing), the members registry will appear.

