### PR TITLE
Nico n users

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,9 @@
 import { Component } from 'solid-js'
-import { createEffect } from 'solid-js'
 
 import './styles.css'
 import Control from './components/Control'
 import User from './components/user/User'
-import { addNewUser, addStatus } from './store/users'
-import { publishedMsgProofs, publishQueue, setPublishedMsgProofs } from './store/store'
+import { addNewUser } from './store/users'
 import PublishedMessages from './components/PublishedMessages'
 
 addNewUser();
@@ -13,26 +11,6 @@ addNewUser();
 
 
 const App: Component = () => {
-
-  createEffect(() => {
-    // Add proofs to the cache from the publish queue (starting from the end)
-    while (publishQueue().length > 0) {
-      const p = publishQueue().shift()
-      if (p == undefined) {
-        break
-      }
-      console.log("Updating Caches")
-
-      addStatus(0, p.proof)
-      addStatus(1, p.proof)
-      const newPublishedMsgProofs =  {
-          message: p.message,
-          proof: p.proof
-      }
-      setPublishedMsgProofs([ ...publishedMsgProofs(), newPublishedMsgProofs ])
-    }
-  })
-
   return (
     <div class="App">
       <h1 class="title">RLNjs Demo</h1>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import './styles.css'
 import Control from './components/Control'
 import User from './components/user/User'
 import { addNewUser } from './store/users'
+import OtherUsers from './components/OtherUsers'
 import PublishedMessages from './components/PublishedMessages'
 
 addNewUser();
@@ -17,15 +18,14 @@ const App: Component = () => {
       <hr />
       <div class="columns">
         <div class="user_left">
+          <h2>Current user</h2>
           <User index={0} />
         </div>
         <div class="controls">
           <Control/>
           <PublishedMessages/>
         </div>
-        <div class="user_right">
-          <User index={1} />
-        </div>
+        <OtherUsers/>
       </div>
     </div >
   )

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,11 +7,11 @@ import { addNewUser } from './store/users'
 import OtherUsers from './components/OtherUsers'
 import PublishedMessages from './components/PublishedMessages'
 
-addNewUser();
-addNewUser();
 
 
 const App: Component = () => {
+  addNewUser();
+  addNewUser();
   return (
     <div class="App">
       <h1 class="title">RLNjs Demo</h1>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import { Component } from 'solid-js'
 import './styles.css'
 import Control from './components/Control'
 import User from './components/user/User'
-import { addNewUser } from './store/users'
+import { addNewUser, users } from './store/users'
 import OtherUsers from './components/OtherUsers'
 import PublishedMessages from './components/PublishedMessages'
 
@@ -19,7 +19,9 @@ const App: Component = () => {
       <div class="columns">
         <div class="user_left">
           <h2>Current user</h2>
-          <User index={0} />
+          {users.map((_, index) => (
+            index == 0 ? <User index={index} /> : null // This is super inneficcient, we need to find a better way
+          ))}
         </div>
         <div class="controls">
           <Control/>

--- a/src/components/OtherUsers.tsx
+++ b/src/components/OtherUsers.tsx
@@ -10,13 +10,13 @@ const OtherUsers = () => {
     return (
         <div class="user_right">
             <div class="other_users_title">
-                <h2>Other users {users().length} </h2>
+                <h2>Other users {users.length} </h2>
                 <button type="button" onClick={handleClick}>
                     Add User
                 </button>
             </div>
             <ul>
-                {users().map((_, index) => (
+                {users.map((_, index) => (
                     index > 0 ? <User index={index} /> : null
                 ))}
             </ul>

--- a/src/components/OtherUsers.tsx
+++ b/src/components/OtherUsers.tsx
@@ -1,0 +1,27 @@
+import { addNewUser, users } from "../store/users"
+import User from "./user/User"
+
+const OtherUsers = () => {
+
+    const handleClick = () => {
+        addNewUser()
+    }
+
+    return (
+        <div class="user_right">
+            <div class="other_users_title">
+                <h2>Other users {users().length} </h2>
+                <button type="button" onClick={handleClick}>
+                    Add User
+                </button>
+            </div>
+            <ul>
+                {users().map((_, index) => (
+                    index > 0 ? <User index={index} /> : null
+                ))}
+            </ul>
+        </div>
+    )
+}
+
+export default OtherUsers

--- a/src/components/PublishedMessages.tsx
+++ b/src/components/PublishedMessages.tsx
@@ -1,5 +1,5 @@
 import { createEffect } from "solid-js"
-import { addStatus } from "../store/users"
+import { addStatus, users } from "../store/users"
 import { publishedMsgProofs, publishQueue, setPublishedMsgProofs } from "../store/store"
 
 const PublishedMessages = () => {
@@ -12,8 +12,11 @@ const PublishedMessages = () => {
       }
       console.log("Updating Caches")
 
-      addStatus(0, p.proof)
-      addStatus(1, p.proof)
+
+      users.map((_, index) => {
+        addStatus(index, p.proof)
+      })
+
       const newPublishedMsgProofs =  {
           message: p.message,
           proof: p.proof

--- a/src/components/PublishedMessages.tsx
+++ b/src/components/PublishedMessages.tsx
@@ -1,6 +1,27 @@
-import { publishedMsgProofs } from "../store/store"
+import { createEffect } from "solid-js"
+import { addStatus } from "../store/users"
+import { publishedMsgProofs, publishQueue, setPublishedMsgProofs } from "../store/store"
 
 const PublishedMessages = () => {
+  createEffect(() => {
+    // Add proofs to the cache from the publish queue (starting from the end)
+    while (publishQueue().length > 0) {
+      const p = publishQueue().shift()
+      if (p == undefined) {
+        break
+      }
+      console.log("Updating Caches")
+
+      addStatus(0, p.proof)
+      addStatus(1, p.proof)
+      const newPublishedMsgProofs =  {
+          message: p.message,
+          proof: p.proof
+      }
+      setPublishedMsgProofs([ ...publishedMsgProofs(), newPublishedMsgProofs ])
+    }
+  })
+
   return (
     <div class="box">
         <h3>

--- a/src/components/user/Cache.tsx
+++ b/src/components/user/Cache.tsx
@@ -1,19 +1,19 @@
 import { poseidon1 } from "poseidon-lite"
-import { EvaluatedProof } from "rlnjs/dist/types/cache"
-import { Accessor } from "solid-js"
+import { users } from "../../store/users"
 
 
 export type Props = {
-  status: Accessor<string[]>
+  index: number
 }
 
-const CacheComponent = ({ status }: Props) => {
+const CacheComponent = ({ index }: Props) => {
+  const user = users[index]
   return (
     <div class="container box">
       <h3>Cache Status</h3>
       <div class="cache">
-        {status().map((str) => {
-          const { status, secret, nullifier, msg }: EvaluatedProof = JSON.parse(str)
+        {user.status.map((proof) => {
+          const { status, secret, nullifier, msg } = proof
           if (status == 'breach') {
             return (
               <div class='cache_proof breach'>

--- a/src/components/user/Message.tsx
+++ b/src/components/user/Message.tsx
@@ -1,64 +1,63 @@
 import { StrBigInt } from "rlnjs"
 import { createSignal } from "solid-js"
-import { ProofType, registryType, rlnType } from "../../store/users"
 import { objectToString } from "../../utils"
 import { epoch, publishQueue, setPublishQueue } from "../../store/store"
+import { setUsers, users } from "../../store/users"
 
 export type Props = {
-  rln: rlnType
-  proof: ProofType
-  registry: registryType
+    index: number
 }
 
-const Message = ({ rln, proof, registry }: Props) => {
+const Message = ({ index }: Props) => {
     const [message, setMessage] = createSignal<string>("")
     const [disableButton, setDisableButton] = createSignal<boolean>(false)
 
-  const handleChange = ({ target }) => {
-    setMessage(target.value.toString())
-  }
+    const user = users[index]
+
+    const handleChange = ({ target }) => {
+      setMessage(target.value.toString())
+    }
 
   const handlePublish = async () => {
     setDisableButton(true)
 
-    console.log("handlePublish Message: " + message())
-    const merkleProof = registry.get().generateMerkleProof(rln.get().commitment)
-    const fullProof = await rln.get().generateProof(
-      message(),
-      merkleProof,
-      epoch() as StrBigInt
-    )
+      console.log("handlePublish Message: " + message())
+      const merkleProof = user.registry.generateMerkleProof( user.rln.commitment )
+      const fullProof = await user.rln.generateProof(
+        message(),
+        merkleProof,
+        epoch() as StrBigInt
+      )
+      setUsers(index, user)
+      setUsers(index, "proof", "Message: '" + message() + "'\n" + "Proof: " + objectToString(fullProof))
 
-    registry.set(registry.get())
-    rln.set(rln.get())
 
-    proof.set("Message: '" + message() + "'\n" + "Proof: " + objectToString(fullProof))
-    console.log("Publishing Proof")
-    const newPublishQueue = {
-      message: message(),
-      proof: fullProof,
+      console.log("Publishing Proof")
+      const newPublishQueue = {
+        message: message(),
+        proof: fullProof,
+      }
+      setPublishQueue([ ...publishQueue(), newPublishQueue ])
+
+      setDisableButton(false)
     }
-    setPublishQueue([...publishQueue(), newPublishQueue])
-    registry.set(registry.get())
-    setDisableButton(false)
-  }
 
     return (
         <div class="message_container box">
             <h3>Message</h3>
             <div class="message_input">
-            <textarea
-              class="message"
-              value={ message() }
-              onChange={handleChange}
-              placeholder={"Put your message here"}
-            ></textarea>
-            <button type="button" class="publish_button" onClick={handlePublish} disabled={ disableButton() }>
-                { disableButton() ? 'Publishing' : 'Publish Message' }
-            </button>
+              <textarea
+                class="message"
+                value={ message() }
+                onChange={handleChange}
+                placeholder={"Put your message here"}
+              ></textarea>
+              <button type="button" class="publish_button" onClick={handlePublish} disabled={ disableButton() }>
+                  { disableButton() ? 'Publishing' : 'Publish Message' }
+              </button>
             </div>
             <h3>Proof</h3>
-            <textarea class="message proof" disabled={true} rows={4} value={ proof.get() || '' }></textarea>
+            <textarea class="message proof" disabled={true} rows={4} value={ user.proof || '' }></textarea>
         </div>
     )
 }

--- a/src/components/user/Message.tsx
+++ b/src/components/user/Message.tsx
@@ -11,7 +11,7 @@ export type Props = {
 }
 
 const Message = ({ rln, proof, registry }: Props) => {
-    const [message, setMessage] = createSignal<string>("Put your message here")
+    const [message, setMessage] = createSignal<string>("")
     const [disableButton, setDisableButton] = createSignal<boolean>(false)
 
     const handleChange = ({ target }) => {
@@ -46,8 +46,13 @@ const Message = ({ rln, proof, registry }: Props) => {
     return (
         <div class="message_container box">
             <h3>Message</h3>
-            <textarea class="message" value={ message() } onChange={handleChange}></textarea>
-            <button type="button" class="publishButton" onClick={handlePublish} disabled={ disableButton() }>
+            <textarea
+              class="message"
+              value={ message() }
+              onChange={handleChange}
+              placeholder={"Put your message here"}
+            ></textarea>
+            <button type="button" class="publish_button" onClick={handlePublish} disabled={ disableButton() }>
                 { disableButton() ? 'Publishing' : 'Publish Message' }
             </button>
             <h3>Proof</h3>

--- a/src/components/user/Message.tsx
+++ b/src/components/user/Message.tsx
@@ -28,7 +28,8 @@ const Message = ({ index }: Props) => {
         merkleProof,
         epoch() as StrBigInt
       )
-      setUsers(index, user)
+      setUsers(index, "registry", user.registry)
+      setUsers(index, "rln", user.rln)
       setUsers(index, "proof", "Message: '" + message() + "'\n" + "Proof: " + objectToString(fullProof))
 
 

--- a/src/components/user/Registry.tsx
+++ b/src/components/user/Registry.tsx
@@ -1,3 +1,4 @@
+import { createEffect, createSignal } from "solid-js"
 import { users } from "../../store/users"
 
 export type Props = {
@@ -5,27 +6,70 @@ export type Props = {
 }
 
 const RegistryComponent = ({ index }: Props) => {
+  const [members, setMembers] = createSignal([(<></>)])
+  const [slashed, setSlashed] = createSignal([(<></>)])
+
+  const user = users[index]
+
+
+  const refresh = () => {
+    const newMembers =  user.registry.members.map((member) => (
+      <li class="bigint">
+        <span style="font-style:italic">MemberID:</span>{" "}
+        {member == 0n ? (
+          <span class="breach" style="font-weight: bold">
+            REMOVED
+          </span>
+        ) : (
+          <span>{member.toString()}</span>
+        )}
+      </li>
+    ))
+    setMembers(newMembers)
+    const newSlashed = user.registry.slashedMembers.map((member) => (
+      <li class="bigint breach">
+        <span style="font-style:italic">MemberID:</span> {member.toString()}
+      </li>
+    ))
+    setSlashed(newSlashed)
+  }
+
+
+  createEffect(() => {
+    const newMembers = user.registry.members.map((member) => (
+      <li class="bigint">
+        <span style="font-style:italic">MemberID:</span>{" "}
+        {member == 0n ? (
+          <span class="breach" style="font-weight: bold">
+            REMOVED
+          </span>
+        ) : (
+          <span>{member.toString()}</span>
+        )}
+      </li>
+    ))
+    setMembers(newMembers)
+  })
+
+  createEffect(() => {
+    const newSlashed = user.registry.slashedMembers.map((member) => (
+      <li class="bigint breach">
+        <span style="font-style:italic">MemberID:</span> {member.toString()}
+      </li>
+    ))
+    setSlashed(newSlashed)
+  })
+
+
   return (
     <div class="container box">
-      <h3>Member Registry</h3>
+      <h3>Member Registry  <button onclick={refresh}>↻</button></h3>
       <ul class="members">
-        {users[index].registry.members.map((member) => {
-          return (
-            <li class="bigint">
-              <span style="font-style:italic">MemberID:</span> {member == 0n ? <span class="breach" style="font-weight: bold">REMOVED</span> : <span>{member.toString()}</span>}
-            </li>
-          )
-        })}
+        {members()}
       </ul>
       <h3>Slashed Registry</h3>
       <ul class="members">
-        {users[index].registry.slashedMembers.map((member) => {
-          return (
-            <li class="bigint breach">
-              <span style="font-style:italic">MemberID:</span> {member.toString()}
-            </li>
-          )
-        })}
+        {slashed()}
       </ul>
     </div>
   )

--- a/src/components/user/Registry.tsx
+++ b/src/components/user/Registry.tsx
@@ -1,15 +1,15 @@
-import { registryType } from "../../store/users"
+import { users } from "../../store/users"
 
 export type Props = {
-    registry: registryType
+  index: number
 }
 
-const RegistryComponent = ({ registry }: Props) => {
+const RegistryComponent = ({ index }: Props) => {
   return (
     <div class="container box">
       <h3>Member Registry</h3>
       <ul class="members">
-        {registry.get().members.map((member) => {
+        {users[index].registry.members.map((member) => {
           return (
             <li class="bigint">
               <span style="font-style:italic">MemberID:</span> {member == 0n ? <span class="breach" style="font-weight: bold">REMOVED</span> : <span>{member.toString()}</span>}
@@ -19,7 +19,7 @@ const RegistryComponent = ({ registry }: Props) => {
       </ul>
       <h3>Slashed Registry</h3>
       <ul class="members">
-        {registry.get().slashedMembers.map((member) => {
+        {users[index].registry.slashedMembers.map((member) => {
           return (
             <li class="bigint breach">
               <span style="font-style:italic">MemberID:</span> {member.toString()}

--- a/src/components/user/Registry.tsx
+++ b/src/components/user/Registry.tsx
@@ -5,8 +5,6 @@ export type Props = {
 }
 
 const RegistryComponent = ({ registry }: Props) => {
-  // TODO: check if registry.get() is reloaded in handlePublish in Message.tsx
-  console.log(registry.get().members)
   return (
     <div class="container box">
       <h3>Member Registry</h3>

--- a/src/components/user/User.tsx
+++ b/src/components/user/User.tsx
@@ -8,7 +8,7 @@ type Props = {
 }
 
 const User = ({ index }: Props) => {
-    const { rln, registry, status, proof } = users()[index];
+    const { rln, registry, status, proof } = users[index];
     return (
         <div>
             <h2>User { index + 1 }</h2>

--- a/src/components/user/User.tsx
+++ b/src/components/user/User.tsx
@@ -1,4 +1,3 @@
-import { users } from "../../store/users"
 import Cache from "./Cache"
 import Message from "./Message"
 import Registry from "./Registry"
@@ -8,17 +7,12 @@ type Props = {
 }
 
 const User = ({ index }: Props) => {
-    const { rln, registry, status, proof } = users[index];
     return (
         <div>
             <h2>User { index + 1 }</h2>
-            <Message
-                rln={rln}
-                proof={proof}
-                registry={registry}
-            />
-            <Cache status={status.get} />
-            <Registry registry={registry} />
+            <Message index={index}/>
+            <Cache index={index} />
+            <Registry index={index} />
         </div>
     )
 }

--- a/src/components/user/User.tsx
+++ b/src/components/user/User.tsx
@@ -8,7 +8,7 @@ type Props = {
 }
 
 const User = ({ index }: Props) => {
-    const { rln, registry, status, proof } = users[index];
+    const { rln, registry, status, proof } = users()[index];
     return (
         <div>
             <h2>User { index + 1 }</h2>

--- a/src/store/users.ts
+++ b/src/store/users.ts
@@ -40,7 +40,7 @@ export type ProofType = {
     set: (proof: string) => void
 }
 
-export const users: UserType[] = []
+export const [users, setUsers] = createSignal<UserType[]>([])
 
 export const addNewUser = () => {
     // create user objects
@@ -55,7 +55,7 @@ export const addNewUser = () => {
 
     // register user itself
     _registry.addMember(_rln.commitment)
-    users.forEach((existingUser) => {
+    users().forEach((existingUser, i) => {
         // new user
         _registry.addMember(existingUser.rln.get().commitment)
         // existing user
@@ -92,11 +92,11 @@ export const addNewUser = () => {
             set: setProof,
         }
     }
-    users.push(user)
+    setUsers([ ...users(), user ])
 }
 
 export const addStatus = (index: number, proof: RLNFullProof) => {
-    const user = users[index]
+    const user = users()[index]
 
     const status = user.cache.get().addProof(proof)
     const newStatus = [...user.status.get(), objectToString(status)]

--- a/src/store/users.ts
+++ b/src/store/users.ts
@@ -1,44 +1,18 @@
-import { Accessor, createSignal } from 'solid-js'
 import { poseidon1 } from 'poseidon-lite'
 import { Registry, RLN, Cache } from 'rlnjs'
 import { createStore } from 'solid-js/store'
 import { RLNFullProof, StrBigInt, VerificationKeyT } from 'rlnjs/dist/types/types'
 
-import { objectToString } from '../utils'
 import vKey from '../zkeyFiles/verification_key.json'
 import { appID } from './store'
+import { EvaluatedProof } from 'rlnjs/dist/types/cache'
 
 export type UserType = {
-    rln: rlnType
-    registry: registryType
-    cache: cacheType
-    status: statusType
-    proof: ProofType
-}
-
-export type rlnType = {
-    get: Accessor<RLN>
-    set: (rln: RLN) => void
-}
-
-export type registryType = {
-    get: Accessor<Registry>
-    set: (registry: Registry) => void
-}
-
-export type cacheType = {
-    get: Accessor<Cache>
-    set: (cache: Cache) => void
-}
-
-export type statusType = {
-    get: Accessor<string[]>
-    set: (status: string[]) => void
-}
-
-export type ProofType = {
-    get: Accessor<string|null>
-    set: (proof: string) => void
+    rln: RLN
+    registry: Registry
+    cache: Cache
+    status: EvaluatedProof[]
+    proof: string|null
 }
 
 export const [users, setUsers] = createStore<UserType[]>([])
@@ -58,40 +32,18 @@ export const addNewUser = () => {
     _registry.addMember(_rln.commitment)
     users.forEach((existingUser, i) => {
         // new user
-        _registry.addMember(existingUser.rln.get().commitment)
+        _registry.addMember(existingUser.rln.commitment)
         // existing user
-        existingUser.registry.get().addMember(_rln.commitment)
-        existingUser.registry.set( existingUser.registry.get() )
+        existingUser.registry.addMember(_rln.commitment)
+        setUsers(i, existingUser)
     })
 
-    // use reactive states
-    const [rln, setRln] = createSignal(_rln)
-    const [registry, setRegistry] = createSignal(_registry)
-    const [cache, setCache] = createSignal(_cache)
-    const [status, setStatus] = createSignal([])
-    const [proof, setProof] = createSignal(null)
-
     const user = {
-        rln: {
-            get: rln,
-            set: setRln,
-        },
-        registry: {
-            get: registry,
-            set: setRegistry,
-        },
-        cache: {
-            get: cache,
-            set: setCache,
-        },
-        status: {
-            get: status,
-            set: setStatus,
-        },
-        proof: {
-            get: proof,
-            set: setProof,
-        }
+        rln: _rln,
+        registry: _registry,
+        cache: _cache,
+        status: [],
+        proof: null,
     }
     setUsers(users.length, user)
 }
@@ -99,14 +51,13 @@ export const addNewUser = () => {
 export const addStatus = (index: number, proof: RLNFullProof) => {
     const user = users[index]
 
-    const status = user.cache.get().addProof(proof)
-    const newStatus = [...user.status.get(), objectToString(status)]
-
-    user.status.set(newStatus)
-    user.cache.set(user.cache.get())
+    const status = user.cache.addProof(proof)
 
     if (status.secret){
-        user.registry.get().slashMember( poseidon1([status.secret]) )
-        user.registry.set( user.registry.get() )
+        user.registry.slashMember( poseidon1([status.secret]) )
     }
+
+    setUsers(index, 'cache', user.cache)
+    setUsers(index, 'status', user.status.length, status)
+    setUsers(index, 'registry', user.registry)
 }

--- a/src/store/users.ts
+++ b/src/store/users.ts
@@ -52,12 +52,11 @@ export const addStatus = (index: number, proof: RLNFullProof) => {
     const user = users[index]
 
     const status = user.cache.addProof(proof)
-
     if (status.secret){
         user.registry.slashMember( poseidon1([status.secret]) )
+        setUsers(index, 'registry', user.registry)
     }
 
     setUsers(index, 'cache', user.cache)
     setUsers(index, 'status', user.status.length, status)
-    setUsers(index, 'registry', user.registry)
 }

--- a/src/store/users.ts
+++ b/src/store/users.ts
@@ -1,6 +1,7 @@
+import { Accessor, createSignal } from 'solid-js'
 import { poseidon1 } from 'poseidon-lite'
 import { Registry, RLN, Cache } from 'rlnjs'
-import { Accessor, createSignal } from 'solid-js'
+import { createStore } from 'solid-js/store'
 import { RLNFullProof, StrBigInt, VerificationKeyT } from 'rlnjs/dist/types/types'
 
 import { objectToString } from '../utils'
@@ -40,7 +41,7 @@ export type ProofType = {
     set: (proof: string) => void
 }
 
-export const [users, setUsers] = createSignal<UserType[]>([])
+export const [users, setUsers] = createStore<UserType[]>([])
 
 export const addNewUser = () => {
     // create user objects
@@ -55,7 +56,7 @@ export const addNewUser = () => {
 
     // register user itself
     _registry.addMember(_rln.commitment)
-    users().forEach((existingUser, i) => {
+    users.forEach((existingUser, i) => {
         // new user
         _registry.addMember(existingUser.rln.get().commitment)
         // existing user
@@ -92,11 +93,11 @@ export const addNewUser = () => {
             set: setProof,
         }
     }
-    setUsers([ ...users(), user ])
+    setUsers(users.length, user)
 }
 
 export const addStatus = (index: number, proof: RLNFullProof) => {
-    const user = users()[index]
+    const user = users[index]
 
     const status = user.cache.get().addProof(proof)
     const newStatus = [...user.status.get(), objectToString(status)]

--- a/src/styles.css
+++ b/src/styles.css
@@ -137,6 +137,7 @@ button {
 }
 
 .message {
+  color: white;
   padding: 0.5rem;
   width: calc(100% - 1rem);
 }
@@ -212,8 +213,13 @@ button {
   width: 32ch;
 }
 
-.publishButton {
+.publish_button {
   font-weight: bold;
+}
+
+.other_users_title {
+  width: 100%;
+  display: inline-flex;
 }
 
 .published_message {

--- a/src/styles.css
+++ b/src/styles.css
@@ -77,6 +77,7 @@ button {
 }
 
 button {
+  cursor: pointer;
   font-weight: bold;
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -137,9 +137,11 @@ button {
 }
 
 .message {
-  color: white;
   padding: 0.5rem;
   width: calc(100% - 1rem);
+}
+.message:disabled{
+  color: white;
 }
 .input {
   display: flex;


### PR DESCRIPTION
1. I changed the users array to a `createStore` array that supposedly maintains reactivity for all elements and their inner attributes (it doesn't x_x). This change get rids of the `user.{rln | registry | cache | ...}.get` and `user.{rln | registry | cache | ...}.set` functions and allows you to directly interact with the attribute as `user.{rln | registry | cache | ...}`. To save the new value you need to use `setUsers( index, {"rln" | "registry" | "cache" | ...}, user.{rln | registry | cache | ...} )`

2. An add user button has been added. Closes #9 .
